### PR TITLE
fix: implement IListContext for MigrationsContext to enable keyboard selection

### DIFF
--- a/pkg/gui/context/migrations_context.go
+++ b/pkg/gui/context/migrations_context.go
@@ -42,6 +42,7 @@ type MigrationsContext struct {
 }
 
 var _ types.Context = &MigrationsContext{}
+var _ types.IListContext = &MigrationsContext{}
 
 type MigrationsContextOpts struct {
 	Gui      *gocui.Gui
@@ -274,6 +275,16 @@ func (m *MigrationsContext) SelectPrev() {
 
 		m.notifySelectionChanged()
 	}
+}
+
+// GetSelectedIdx returns the index of the currently selected item.
+func (m *MigrationsContext) GetSelectedIdx() int {
+	return m.selected
+}
+
+// GetItemCount returns the number of items in the current tab.
+func (m *MigrationsContext) GetItemCount() int {
+	return len(m.items)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- MigrationsContext was missing `GetSelectedIdx()` and `GetItemCount()`, so it did not satisfy `IListContext`
- The keybinding handler fell through to `IScrollableContext`, causing arrow keys to scroll the view rather than move the selection
- Added the two missing methods and a compile-time interface check

## Test plan
- [ ] Launch lazyprisma in a Prisma project with migrations
- [ ] Focus the Migrations panel and press `↑`/`↓` — verify the selection highlight moves between items
- [ ] Verify scrolling still works correctly when the list exceeds the panel height
- [ ] Verify `Home`/`End` keys still jump to first/last item